### PR TITLE
Fix an overflow when the left and right side have different lengths.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+use std::cmp;
+
 /// A fragment of a computed diff.
 #[derive(Clone, Debug, PartialEq)]
 pub enum Result<T> {
@@ -27,6 +29,7 @@ fn iter<'a, I, T>(left: I, right: I) -> Vec<Result<T>> where
 {
     let left_count = left.clone().count();
     let right_count = right.clone().count();
+    let min_count = cmp::min(left_count, right_count);
 
     let leading_equals = left.clone()
                              .zip(right.clone())
@@ -35,7 +38,7 @@ fn iter<'a, I, T>(left: I, right: I) -> Vec<Result<T>> where
     let trailing_equals = left.clone()
                               .rev()
                               .zip(right.clone().rev())
-                              .take(left_count - leading_equals)
+                              .take(min_count - leading_equals)
                               .take_while(|p| p.0 == p.1)
                               .count();
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -50,6 +50,47 @@ pub fn undiff_chars<'a>(diff: &[::diff::Result<char>]) -> (String, String) {
     (left.iter().cloned().collect(), right.iter().cloned().collect())
 }
 
+#[test]
+fn uneven_diff() {
+    // This produced an overflow in the lines computation because it
+    // was not accounting for the fact that the "right" length was
+    // less than the "left" length.
+    let expected = r#"
+BacktraceNode {
+    parents: [
+        BacktraceNode {
+            parents: []
+        },
+        BacktraceNode {
+            parents: [
+                BacktraceNode {
+                    parents: []
+                }
+            ]
+        }
+    ]
+}"#;
+    let actual = r#"
+BacktraceNode {
+    parents: [
+        BacktraceNode {
+            parents: []
+        },
+        BacktraceNode {
+            parents: [
+                BacktraceNode {
+                    parents: []
+                },
+                BacktraceNode {
+                    parents: []
+                }
+            ]
+        }
+    ]
+}"#;
+    diff::lines(actual, expected);
+}
+
 speculate! {
     describe "slice" {
         before {


### PR DESCRIPTION
I encountered this overflow while using diff. It seems likely that the test can be minimized further, but I didn't quite dig deeply enough to do so. :)