### PR TITLE
chore(dependency): bump speculate to 0.0.22

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,5 @@ homepage = "https://github.com/utkarshkukreti/diff.rs"
 repository = "https://github.com/utkarshkukreti/diff.rs"
 
 [dev-dependencies]
-speculate = "0.0.20"
+speculate = "0.0.22"
 quickcheck = "0.2.16"


### PR DESCRIPTION
Initially, when running tests I got a compile error from inside `speculate`. This was fixed by bumping the `speculate` version.