### PR TITLE
fix(lines): fix case when either or both strings end with '\n'

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,18 @@ pub fn slice<'a, T: PartialEq>(left: &'a [T], right: &'a [T]) -> Vec<Result<&'a 
 
 /// Computes the diff between the lines of two strings.
 pub fn lines<'a>(left: &'a str, right: &'a str) -> Vec<Result<&'a str>> {
-    iter(left.lines(), right.lines())
+    let mut diff = iter(left.lines(), right.lines());
+    // str::lines() does not yield an empty str at the end if the str ends with
+    // '\n'. We handle this special case by inserting one last diff item,
+    // depending on whether the left string ends with '\n', or the right one,
+    // or both.
+    match (left.as_bytes().last().cloned(), right.as_bytes().last().cloned()) {
+        (Some(b'\n'), Some(b'\n')) => diff.push(Result::Both(&left[left.len()..], &right[right.len()..])),
+        (Some(b'\n'), _) => diff.push(Result::Left(&left[left.len()..])),
+        (_, Some(b'\n')) => diff.push(Result::Right(&right[right.len()..])),
+        _ => {},
+    }
+    diff
 }
 
 /// Computes the diff between the chars of two strings.

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -137,6 +137,15 @@ speculate! {
         test "misc 1" {
             go("foo\nbar\nbaz", "foo\nbaz\nquux", 4);
         }
+
+        test "#10" {
+            go("a\nb\nc", "a\nb\nc\n", 4);
+            go("a\nb\nc\n", "a\nb\nc", 4);
+            let left = "a\nb\n\nc\n\n\n";
+            let right = "a\n\n\nc\n\n";
+            go(left, right, 8);
+            go(right, left, 8);
+        }
     }
 
     describe "chars" {


### PR DESCRIPTION
Fixes #10.