### PR TITLE
Add #![forbid(unsafe_code)]

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 /// A fragment of a computed diff.
 #[derive(Clone, Debug, PartialEq)]
 pub enum Result<T> {


### PR DESCRIPTION
Documents no usage of unsafe.

This is nice for library consumers with auditing processes for third-party Rust dependencies.