### PR TITLE
Add `serde` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,9 @@ documentation = "https://docs.rs/diff"
 homepage = "https://github.com/utkarshkukreti/diff.rs"
 repository = "https://github.com/utkarshkukreti/diff.rs"
 
+[dependencies]
+serde = { version = "1", features = ["derive"], optional = true }
+
 [dev-dependencies]
 speculate = "0.1.2"
 quickcheck = "1.0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 
 /// A fragment of a computed diff.
 #[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Result<T> {
     /// An element that only exists in the left input.
     Left(T),


### PR DESCRIPTION
Add optional `serde` feature which derives `Serialize` and `Deserialize` for `Result` when enabled.